### PR TITLE
feat: CI/CD for publishing to npmjs.com

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish NPM package
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+
+      - run: git fetch --all --tags
+        
+      - name: Check version change
+        uses: thebongy/version-check@v1
+        id: check
+        with:
+          file: package.json
+          failBuild: false
+          tagFormat: v${version}
+      
+      - name: Echo variables
+        run: |
+          echo "versionChanged- ${{steps.check.outputs.versionChanged}}"
+          echo "releaseVersion- ${{steps.check.outputs.releaseVersion}}"
+
+      - if: steps.check.outputs.versionChanged == 'true'
+        run: npm install
+
+      - if: steps.check.outputs.versionChanged == 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+test
+.github
+node_modules
+dist/cli
+.env
+.eslintignore
+.eslintrc.json
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+examples
+config
+.gitignore
+tsconfig.json
+src

--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ config
 .gitignore
 tsconfig.json
 src
+.all-contributorsrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-executor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A CLI/library to execute code against test cases in various languages and obtain relevant results.",
   "main": "dist/src/CodeExecutor.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,15 +1,23 @@
 {
   "name": "code-executor",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A CLI/library to execute code against test cases in various languages and obtain relevant results.",
-  "main": "dist/codeExecutor.js",
+  "main": "dist/src/CodeExecutor.js",
+  "keywords": [
+    "code-executor",
+    "executor",
+    "docker",
+    "sandbox",
+    "synchronization",
+    "parallel-execution",
+    "code-runner"
+  ],
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rimraf ./dist",
     "test": "mocha --config test/.mocharc.json test/**/*.ts",
     "lint": "eslint \"src/**/*.{ts,js,jsx}\" \"test/**/*.ts\" \"examples/**/*.{ts,js}\"",
     "lint:fix": "eslint --fix \"src/**/*.{ts,js,jsx}\" \"test/**/*.ts\" \"examples/**/*.{ts,js}\"",
-    "start": "ts-node src/codeExecutor.ts",
     "prepare": "npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-executor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A CLI/library to execute code against test cases in various languages and obtain relevant results.",
   "main": "dist/src/CodeExecutor.js",
   "keywords": [


### PR DESCRIPTION
- CI/CD in `.github/workflows/publish.yml` publishes to `https://www.npmjs.com/package/code-executor`