### PR TITLE
feat: Added basic CLI

### DIFF
--- a/bin/code-executor
+++ b/bin/code-executor
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../dist/src/index').cli(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "code-executor",
-<<<<<<< HEAD
-  "version": "0.2.1",
-=======
-  "version": "0.2.2",
->>>>>>> master
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -120,6 +116,15 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
+      "dev": true,
+      "requires": {
+        "commander": "*"
+      }
     },
     "@types/dockerode": {
       "version": "2.5.34",
@@ -667,6 +672,11 @@
         "color": "3.0.x",
         "text-hex": "1.0.x"
       }
+    },
+    "commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
     },
     "compare-versions": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/csivitu/code-executor#readme",
   "devDependencies": {
     "@types/bull": "^3.14.2",
+    "@types/commander": "^2.12.2",
     "@types/dockerode": "^2.5.34",
     "@types/node": "^14.6.3",
     "@types/randomstring": "^1.1.6",
@@ -56,6 +57,7 @@
   },
   "dependencies": {
     "bull": "^3.18.0",
+    "commander": "^6.2.0",
     "del": "^6.0.0",
     "dockerode": "^3.2.1",
     "randomstring": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "parallel-execution",
     "code-runner"
   ],
+  "bin": {
+    "code-executor": "bin/code-executor"
+  },
   "scripts": {
     "build": "npm run clean && tsc && npm run build:dockerfiles",
     "build:dockerfiles": "shx cp -r src/langs dist/src/langs",

--- a/src/WorkerCLI.ts
+++ b/src/WorkerCLI.ts
@@ -1,0 +1,63 @@
+import commander, { Command } from 'commander';
+import logger from './utils/logger';
+import { WorkerCLIOptions } from './models';
+import Worker from './Worker';
+
+class WorkerCLI {
+    readonly program: commander.Command;
+
+    readonly args: string[];
+
+    constructor(args: string[]) {
+        this.program = new Command();
+        this.args = args;
+        this.init();
+    }
+
+    init(): void {
+        this.program
+            .command('spawn-worker')
+            .alias('sw')
+            .description('spawn worker process')
+            .action(() => {
+                const options = this.parseOptions();
+                WorkerCLI.spawnWorker(options);
+            });
+
+        this.program
+            .option('-n, --number <number>', 'number of workers')
+            .option('-r, --redis <redis>', 'URL for the redis instance')
+            .option('-q, --queue <queue>', 'name of the redis queue')
+            .option('-l, --langs <langs...>', 'list of languages to build');
+    }
+
+    parseOptions(): WorkerCLIOptions {
+        const opts = this.program.opts();
+
+        const options: WorkerCLIOptions = {
+            number: opts.number || 1,
+            redis: opts.redis || 'redis://127.0.0.1:6379',
+            queue: opts.queue || 'myExecutor',
+            langs: opts.langs || [],
+        };
+
+        return options;
+    }
+
+    static async spawnWorker(options: WorkerCLIOptions): Promise<void> {
+        logger.info('Spawning Workers...');
+
+        const worker = new Worker(options.queue, options.redis);
+        await worker.build(options.langs.length ? options.langs : undefined);
+        worker.start();
+    }
+
+    async start(): Promise<void> {
+        await this.program.parseAsync(this.args);
+    }
+}
+
+export default async function cli(args: string[]): Promise<void> {
+    const workerCLI = new WorkerCLI(args);
+    workerCLI.start();
+}

--- a/src/WorkerCLI.ts
+++ b/src/WorkerCLI.ts
@@ -25,7 +25,6 @@ class WorkerCLI {
             });
 
         this.program
-            .option('-n, --number <number>', 'number of workers')
             .option('-r, --redis <redis>', 'URL for the redis instance')
             .option('-q, --queue <queue>', 'name of the redis queue')
             .option('-l, --langs <langs...>', 'list of languages to build');
@@ -35,7 +34,6 @@ class WorkerCLI {
         const opts = this.program.opts();
 
         const options: WorkerCLIOptions = {
-            number: opts.number || 1,
             redis: opts.redis || 'redis://127.0.0.1:6379',
             queue: opts.queue || 'myExecutor',
             langs: opts.langs || [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export { default as CodeExecutor, languages } from './CodeExecutor';
 
 export { default as Worker } from './Worker';
+
+export { default as cli } from './WorkerCLI';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -37,7 +37,6 @@ export interface WorkerOptions {
 }
 
 export interface WorkerCLIOptions {
-    number: number;
     queue: string;
     redis: string;
     langs: string[];

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -35,3 +35,10 @@ export interface WorkerOptions {
     memory?: number;
     CPUs?: number;
 }
+
+export interface WorkerCLIOptions {
+    number: number;
+    queue: string;
+    redis: string;
+    langs: string[];
+}


### PR DESCRIPTION
# feat: Added basic CLI

- CLI takes the following options:

```js
.option('-r, --redis <redis>', 'URL for the redis instance')
.option('-q, --queue <queue>', 'name of the redis queue')
.option('-l, --langs <langs...>', 'list of languages to build');
```

- A list of languages is accepted - if none provided, all containers are built.